### PR TITLE
Feat/messaging on client

### DIFF
--- a/src/chat.tsx
+++ b/src/chat.tsx
@@ -1,20 +1,11 @@
 import React from "react";
 import { ItemContent, Virtuoso } from "react-virtuoso";
 import cn from "clsx";
-import {
-  MessageSender,
-  MessageStatus,
-  type Message,
-} from "../__generated__/resolvers-types";
-import css from "./chat.module.css";
 
-const temp_data: Message[] = Array.from(Array(30), (_, index) => ({
-  id: String(index),
-  text: `Message number ${index}`,
-  status: MessageStatus.Read,
-  updatedAt: new Date().toISOString(),
-  sender: index % 2 ? MessageSender.Admin : MessageSender.Customer,
-}));
+import { MessageSender, type Message } from "../__generated__/resolvers-types";
+import { useMessages } from "./hooks/use-messages";
+
+import css from "./chat.module.css";
 
 const Item: React.FC<Message> = ({ text, sender }) => {
   return (
@@ -36,10 +27,17 @@ const getItem: ItemContent<Message, unknown> = (_, data) => {
 };
 
 export const Chat: React.FC = () => {
+  const { messages, loadMoreMessages } = useMessages();
+
   return (
     <div className={css.root}>
       <div className={css.container}>
-        <Virtuoso className={css.list} data={temp_data} itemContent={getItem} />
+        <Virtuoso
+          className={css.list}
+          data={messages}
+          itemContent={getItem}
+          endReached={loadMoreMessages}
+        />
       </div>
       <div className={css.footer}>
         <input

--- a/src/chat.tsx
+++ b/src/chat.tsx
@@ -3,7 +3,8 @@ import { ItemContent, Virtuoso } from "react-virtuoso";
 import cn from "clsx";
 
 import { MessageSender, type Message } from "../__generated__/resolvers-types";
-import { useMessages } from "./hooks/use-messages";
+import { useGetMessages } from "./hooks/use-get-messages";
+import { useSendMessage } from "./hooks/use-send-message";
 
 import css from "./chat.module.css";
 
@@ -27,7 +28,9 @@ const getItem: ItemContent<Message, unknown> = (_, data) => {
 };
 
 export const Chat: React.FC = () => {
-  const { messages, loadMoreMessages } = useMessages();
+  const { messages, loadMoreMessages } = useGetMessages();
+  const { messageText, setMessageText, handleSendMessage, sendingMessage } =
+    useSendMessage();
 
   return (
     <div className={css.root}>
@@ -39,14 +42,18 @@ export const Chat: React.FC = () => {
           endReached={loadMoreMessages}
         />
       </div>
-      <div className={css.footer}>
+      <form className={css.footer} onSubmit={handleSendMessage}>
         <input
           type="text"
           className={css.textInput}
           placeholder="Message text"
+          value={messageText}
+          onChange={(e) => setMessageText(e.target.value)}
         />
-        <button>Send</button>
-      </div>
+        <button type="submit" disabled={sendingMessage || !messageText.trim()}>
+          {sendingMessage ? "Sending..." : "Send"}
+        </button>
+      </form>
     </div>
   );
 };

--- a/src/chat.tsx
+++ b/src/chat.tsx
@@ -5,6 +5,7 @@ import cn from "clsx";
 import { MessageSender, type Message } from "../__generated__/resolvers-types";
 import { useGetMessages } from "./hooks/use-get-messages";
 import { useSendMessage } from "./hooks/use-send-message";
+import { useMessageSubscriptions } from "./hooks/use-message-subscriptions";
 
 import css from "./chat.module.css";
 
@@ -31,6 +32,8 @@ export const Chat: React.FC = () => {
   const { messages, loadMoreMessages } = useGetMessages();
   const { messageText, setMessageText, handleSendMessage, sendingMessage } =
     useSendMessage();
+
+  useMessageSubscriptions();
 
   return (
     <div className={css.root}>

--- a/src/hooks/constants.ts
+++ b/src/hooks/constants.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_PAGE_SIZE = 10;
+
+export const MESSAGES_QUERY_OPTIONS = {
+  errorPolicy: "all" as const,
+};

--- a/src/hooks/use-get-messages.ts
+++ b/src/hooks/use-get-messages.ts
@@ -5,7 +5,7 @@ import { Message } from "../../__generated__/resolvers-types";
 import { GET_MESSAGES } from "../queries/messages";
 import { DEFAULT_PAGE_SIZE, MESSAGES_QUERY_OPTIONS } from "./constants";
 
-export const useMessages = (pageSize: number = DEFAULT_PAGE_SIZE) => {
+export const useGetMessages = (pageSize: number = DEFAULT_PAGE_SIZE) => {
   const { data, loading, fetchMore, error } = useQuery(GET_MESSAGES, {
     variables: { first: pageSize },
     ...MESSAGES_QUERY_OPTIONS,

--- a/src/hooks/use-message-subscriptions.ts
+++ b/src/hooks/use-message-subscriptions.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useSubscription } from "@apollo/client";
+import { useApolloClient } from "@apollo/client";
+
+import { addMessageToCache, updateMessageInCache } from "./utils";
+import {
+  MESSAGE_ADDED_SUBSCRIPTION,
+  MESSAGE_UPDATED_SUBSCRIPTION,
+} from "../queries/messages";
+
+export const useMessageSubscriptions = () => {
+  const client = useApolloClient();
+
+  const { data: newMessageData } = useSubscription(MESSAGE_ADDED_SUBSCRIPTION);
+
+  const { data: updatedMessageData } = useSubscription(
+    MESSAGE_UPDATED_SUBSCRIPTION
+  );
+
+  useEffect(() => {
+    if (newMessageData?.messageAdded) {
+      addMessageToCache(client.cache, newMessageData.messageAdded);
+    }
+  }, [newMessageData, client.cache]);
+
+  useEffect(() => {
+    if (updatedMessageData?.messageUpdated) {
+      updateMessageInCache(client.cache, updatedMessageData.messageUpdated);
+    }
+  }, [updatedMessageData, client.cache]);
+
+  return {
+    newMessage: newMessageData?.messageAdded,
+    updatedMessage: updatedMessageData?.messageUpdated,
+  };
+};

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+
+import { Message } from "../../__generated__/resolvers-types";
+import { GET_MESSAGES } from "../queries/messages";
+import { DEFAULT_PAGE_SIZE, MESSAGES_QUERY_OPTIONS } from "./constants";
+
+export const useMessages = (pageSize: number = DEFAULT_PAGE_SIZE) => {
+  const { data, loading, fetchMore, error } = useQuery(GET_MESSAGES, {
+    variables: { first: pageSize },
+    ...MESSAGES_QUERY_OPTIONS,
+  });
+
+  const messages = useMemo(
+    () =>
+      data?.messages?.edges?.map((edge: { node: Message }) => edge.node) || [],
+    [data]
+  );
+
+  const pageInfo = data?.messages?.pageInfo;
+
+  const loadMoreMessages = useCallback(async () => {
+    if (!pageInfo?.hasNextPage || loading) return;
+
+    try {
+      await fetchMore({
+        variables: { first: pageSize, after: pageInfo.endCursor },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+          return {
+            messages: {
+              ...fetchMoreResult.messages,
+              edges: [
+                ...prev.messages.edges,
+                ...fetchMoreResult.messages.edges,
+              ],
+            },
+          };
+        },
+      });
+    } catch (err) {
+      console.error("Error loading more messages:", err);
+    }
+  }, [fetchMore, pageInfo, loading, pageSize]);
+
+  return {
+    messages,
+    loading,
+    error,
+    loadMoreMessages,
+    hasNextPage: pageInfo?.hasNextPage,
+  };
+};

--- a/src/hooks/use-send-message.ts
+++ b/src/hooks/use-send-message.ts
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { useMutation } from "@apollo/client";
+
+import { updateMessagesCache } from "./utils";
+import { SEND_MESSAGE } from "../queries/messages";
+
+export const useSendMessage = () => {
+  const [messageText, setMessageText] = useState("");
+
+  const [sendMessageMutation, { loading: sendingMessage, error }] = useMutation(
+    SEND_MESSAGE,
+    {
+      update(cache, { data }) {
+        if (!data?.sendMessage) return;
+        updateMessagesCache(cache, data.sendMessage);
+      },
+      onError: (error) => {
+        console.error("Error sending message:", error);
+      },
+    }
+  );
+
+  const sendMessage = async (text: string) => {
+    if (!text.trim() || sendingMessage) return;
+
+    try {
+      await sendMessageMutation({
+        variables: { text: text.trim() },
+      });
+    } catch (error) {
+      console.error("Error sending message:", error);
+    }
+  };
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await sendMessage(messageText);
+    setMessageText("");
+  };
+
+  return {
+    messageText,
+    setMessageText,
+    sendMessage,
+    handleSendMessage,
+    sendingMessage,
+    error,
+  };
+};

--- a/src/hooks/use-send-message.ts
+++ b/src/hooks/use-send-message.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client";
 
-import { updateMessagesCache } from "./utils";
+import { addMessageToCache } from "./utils";
 import { SEND_MESSAGE } from "../queries/messages";
 
 export const useSendMessage = () => {
@@ -12,7 +12,7 @@ export const useSendMessage = () => {
     {
       update(cache, { data }) {
         if (!data?.sendMessage) return;
-        updateMessagesCache(cache, data.sendMessage);
+        addMessageToCache(cache, data.sendMessage);
       },
       onError: (error) => {
         console.error("Error sending message:", error);

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PAGE_SIZE } from "../hooks/constants";
 import { GET_MESSAGES } from "../queries/messages";
 import { Message } from "../../__generated__/resolvers-types";
 
-export const updateMessagesCache = (
+export const addMessageToCache = (
   cache: ApolloCache<any>,
   newMessage: Message
 ) => {
@@ -28,23 +28,80 @@ export const updateMessagesCache = (
     variables: { first: DEFAULT_PAGE_SIZE },
   });
 
-  if (existingData?.messages) {
-    cache.writeQuery({
-      query: GET_MESSAGES,
-      variables: { first: DEFAULT_PAGE_SIZE },
-      data: {
-        messages: {
-          ...existingData.messages,
-          edges: [
-            ...existingData.messages.edges,
-            {
-              node: newMessage,
-              cursor: newMessage.id,
-              __typename: "MessageEdge",
-            },
-          ],
+  if (!existingData?.messages) return;
+
+  const messageExists = existingData.messages.edges.some(
+    (edge) => edge.node.id === newMessage.id
+  );
+
+  if (messageExists) return;
+
+  const newEdge = {
+    node: newMessage,
+    cursor: newMessage.id,
+    __typename: "MessageEdge",
+  };
+
+  cache.writeQuery({
+    query: GET_MESSAGES,
+    variables: { first: DEFAULT_PAGE_SIZE },
+    data: {
+      messages: {
+        ...existingData.messages,
+        edges: [...existingData.messages.edges, newEdge],
+        pageInfo: {
+          ...existingData.messages.pageInfo,
+          endCursor: newMessage.id,
         },
       },
-    });
-  }
+    },
+  });
+};
+
+export const updateMessageInCache = (
+  cache: ApolloCache<any>,
+  updatedMessage: Message
+) => {
+  const existingData = cache.readQuery<{
+    messages: {
+      edges: Array<{
+        node: Message;
+        cursor: string;
+        __typename: string;
+      }>;
+      pageInfo: {
+        hasNextPage: boolean;
+        hasPreviousPage: boolean;
+        startCursor: string;
+        endCursor: string;
+      };
+      __typename: string;
+    };
+  }>({
+    query: GET_MESSAGES,
+    variables: { first: DEFAULT_PAGE_SIZE },
+  });
+
+  if (!existingData?.messages) return;
+
+  const updatedEdges = existingData.messages.edges.map((edge) => {
+    if (edge.node.id === updatedMessage.id) {
+      return {
+        ...edge,
+        node: updatedMessage,
+      };
+    }
+    return edge;
+  });
+
+  cache.writeQuery({
+    query: GET_MESSAGES,
+    variables: { first: DEFAULT_PAGE_SIZE },
+    data: {
+      messages: {
+        ...existingData.messages,
+        edges: updatedEdges,
+      },
+    },
+  });
 };

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -86,10 +86,16 @@ export const updateMessageInCache = (
 
   const updatedEdges = existingData.messages.edges.map((edge) => {
     if (edge.node.id === updatedMessage.id) {
-      return {
-        ...edge,
-        node: updatedMessage,
-      };
+      const existingUpdatedAt = new Date(edge.node.updatedAt);
+      const newUpdatedAt = new Date(updatedMessage.updatedAt);
+
+      if (newUpdatedAt > existingUpdatedAt) {
+        return {
+          ...edge,
+          node: updatedMessage,
+        };
+      }
+      return edge;
     }
     return edge;
   });

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,0 +1,50 @@
+import { ApolloCache } from "@apollo/client";
+
+import { DEFAULT_PAGE_SIZE } from "../hooks/constants";
+import { GET_MESSAGES } from "../queries/messages";
+import { Message } from "../../__generated__/resolvers-types";
+
+export const updateMessagesCache = (
+  cache: ApolloCache<any>,
+  newMessage: Message
+) => {
+  const existingData = cache.readQuery<{
+    messages: {
+      edges: Array<{
+        node: Message;
+        cursor: string;
+        __typename: string;
+      }>;
+      pageInfo: {
+        hasNextPage: boolean;
+        hasPreviousPage: boolean;
+        startCursor: string;
+        endCursor: string;
+      };
+      __typename: string;
+    };
+  }>({
+    query: GET_MESSAGES,
+    variables: { first: DEFAULT_PAGE_SIZE },
+  });
+
+  if (existingData?.messages) {
+    cache.writeQuery({
+      query: GET_MESSAGES,
+      variables: { first: DEFAULT_PAGE_SIZE },
+      data: {
+        messages: {
+          ...existingData.messages,
+          edges: [
+            ...existingData.messages.edges,
+            {
+              node: newMessage,
+              cursor: newMessage.id,
+              __typename: "MessageEdge",
+            },
+          ],
+        },
+      },
+    });
+  }
+};

--- a/src/queries/messages.ts
+++ b/src/queries/messages.ts
@@ -1,0 +1,24 @@
+import { gql } from "@apollo/client";
+
+export const GET_MESSAGES = gql`
+  query GetMessages($first: Int, $after: MessagesCursor) {
+    messages(first: $first, after: $after) {
+      edges {
+        node {
+          id
+          text
+          status
+          updatedAt
+          sender
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+`;

--- a/src/queries/messages.ts
+++ b/src/queries/messages.ts
@@ -34,3 +34,27 @@ export const SEND_MESSAGE = gql`
     }
   }
 `;
+
+export const MESSAGE_ADDED_SUBSCRIPTION = gql`
+  subscription MessageAdded {
+    messageAdded {
+      id
+      text
+      status
+      updatedAt
+      sender
+    }
+  }
+`;
+
+export const MESSAGE_UPDATED_SUBSCRIPTION = gql`
+  subscription MessageUpdated {
+    messageUpdated {
+      id
+      text
+      status
+      updatedAt
+      sender
+    }
+  }
+`;

--- a/src/queries/messages.ts
+++ b/src/queries/messages.ts
@@ -22,3 +22,15 @@ export const GET_MESSAGES = gql`
     }
   }
 `;
+
+export const SEND_MESSAGE = gql`
+  mutation SendMessage($text: String!) {
+    sendMessage(text: $text) {
+      id
+      text
+      status
+      updatedAt
+      sender
+    }
+  }
+`;


### PR DESCRIPTION
1. Replace the temp_data variable on the client-side with a query to fetch messages from the Apollo server. Messages should be fetched with pagination.
2. Implement message sending using Apollo Client's useMutation hook.
3. Handle receiving new messages and updating existing messages through GraphQL subscriptions.

NOTE: The server does not add the message generated by asyncReplyMessage to messages